### PR TITLE
fix(packge.json): allow react 17 support

### DIFF
--- a/react-native-okra-expo/package.json
+++ b/react-native-okra-expo/package.json
@@ -30,7 +30,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1",
+    "react": ">=16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x",
     "expo-device": "^3.1.1",
     "expo-constants": "^10.0.1",


### PR DESCRIPTION
# Description
Addresses the problem mentioned in this issue https://github.com/okraHQ/react-native-expo/issues/20 currently the library does not install on a React Native project that uses anything higher than React 16.

# Fixes # ([20](https://github.com/okraHQ/react-native-expo/issues/20))

# What Was Done
+ updated the dependency to allow newer versions of React.

# How Do I Test?
- Set up a fresh React Native(version 0.66) app that depends on React 17.
- Try installing this library on the new project.
